### PR TITLE
Fix frontend API proxy to backend

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- proxy API calls from Vite dev server to backend

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865182a1a84833297656eab7be9400d