### PR TITLE
Fix build by adding drawing utils dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@mediapipe/camera_utils": "^0.3.1675466862",
+        "@mediapipe/drawing_utils": "^0.3.1675466124",
         "@mediapipe/face_mesh": "^0.4.1633559619",
         "axios": "^1.10.0",
         "canny-edge-detector": "^1.0.0",
@@ -1057,6 +1058,12 @@
       "version": "0.3.1675466862",
       "resolved": "https://registry.npmjs.org/@mediapipe/camera_utils/-/camera_utils-0.3.1675466862.tgz",
       "integrity": "sha512-siuXBoUxWo9WL0MeAxIxvxY04bvbtdNl7uCxoJxiAiRtNnCYrurr7Vl5VYQ94P7Sq0gVq6PxIDhWWeZ/pLnSzw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@mediapipe/drawing_utils": {
+      "version": "0.3.1675466124",
+      "resolved": "https://registry.npmjs.org/@mediapipe/drawing_utils/-/drawing_utils-0.3.1675466124.tgz",
+      "integrity": "sha512-/IWIB/iYRMtiUKe3k7yGqvwseWHCOqzVpRDfMgZ6gv9z7EEimg6iZbRluoPbcNKHbYSxN5yOvYTzUYb8KVf22Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@mediapipe/face_mesh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@mediapipe/camera_utils": "^0.3.1675466862",
+    "@mediapipe/drawing_utils": "^0.3.1675466124",
     "@mediapipe/face_mesh": "^0.4.1633559619",
     "axios": "^1.10.0",
     "canny-edge-detector": "^1.0.0",


### PR DESCRIPTION
## Summary
- add missing `@mediapipe/drawing_utils` dependency
- regenerate lock file

## Testing
- `pytest -q`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686cdc81a6048332ab44b7149219c29a