### PR TITLE
Add API host selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ npm run dev
 
 The frontend uses [Three.js](https://threejs.org/) for a 3D overlay on the live
 camera stream. Running `npm install` will install this dependency automatically.
+
+### API base URL
+
+When running the development servers locally (`uvicorn` and `npm run dev`) the
+frontend automatically calls `http://localhost:8000/api`. During a production
+build the API base defaults to `https://facefit-nntu.onrender.com/api`. You can
+override this by setting the `VITE_API_BASE` environment variable when starting
+Vite or building the app.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,7 +5,11 @@ import { drawConnectors } from '@mediapipe/drawing_utils'
 import * as THREE from 'three'
 import './index.css'
 
-const API_BASE = 'https://facefit-nntu.onrender.com/api'
+const API_BASE =
+  import.meta.env.VITE_API_BASE ||
+  (import.meta.env.DEV
+    ? 'http://localhost:8000/api'
+    : 'https://facefit-nntu.onrender.com/api')
 const API_URL = `${API_BASE}/analyze-face`
 const LOGS_URL = `${API_BASE}/logs`
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/api': 'https://facefit-nntu.onrender.com',
+      '/api': 'http://localhost:8000',
     },
   },
 })


### PR DESCRIPTION
## Summary
- set API base based on `import.meta.env`
- use localhost proxy in Vite dev server
- document API base override

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_6870d33630148332a88f5da10840d962